### PR TITLE
Fix documentation symlink warning

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -27,8 +27,11 @@ if not option.disabled()
             input : guideindex_xml,
             output : ['html'],
             command : [gnome_doc_tool, 'html', '@INPUT@', '-o', destdir, '-p', graphicsdir],
-            install : true,
-            install_dir : helpdir)
+            install : false)
+        install_subdir(destdir,
+            install_dir : helpdir,
+            install_tag : 'help',
+            follow_symlinks : false)
         run_command(find_program('ln'), '-s', '-f', 'GuideIndex.html', guideindex_ln, check : false)
         summary({'help' : ['Help files created:', true]}, section : 'Documentation', bool_yn : true)
     else


### PR DESCRIPTION
## Summary
- install doc/html directory with follow_symlinks=false

## Testing
- `meson setup build`
- `meson test -C build` *(fails: Ancillary files)*

------
https://chatgpt.com/codex/tasks/task_e_684b3cb4e47c8333a041f31bba5fa05c