### PR TITLE
Fix dark theme icon detection

### DIFF
--- a/src/pixbuf-util.cc
+++ b/src/pixbuf-util.cc
@@ -181,11 +181,12 @@ GdkPixbuf *pixbuf_inline(const gchar *key)
 	GInputStream *in_stream;
 
 	if (!key) return nullptr;
-
+	
 	GtkSettings *settings = gtk_settings_get_default();
 	g_autofree gchar *theme_name = nullptr;
 	g_object_get(settings, "gtk-theme-name", &theme_name, nullptr);
-	gboolean dark = g_str_has_suffix(theme_name, "dark");
+	g_autofree gchar *theme_name_lc = g_ascii_strdown(theme_name, -1);
+	gboolean dark = g_str_has_suffix(theme_name_lc, "dark");
 
 	const auto it = std::find_if(std::cbegin(inline_pixbuf_data), std::cend(inline_pixbuf_data),
 	                             [key](const PixbufInline &pi){ return strcmp(pi.key, key) == 0; });


### PR DESCRIPTION
## Summary
- detect dark themes using case-insensitive check

## Testing
- `meson setup build`
- `meson test -C build` *(fails: Ancillary files, several tests interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684ebbbcd79c83338c9cf459da3b05cc