### PR TITLE
Change toolbar icon when metadata pending

### DIFF
--- a/src/layout-util.cc
+++ b/src/layout-util.cc
@@ -3678,19 +3678,60 @@ void layout_toolbar_add_from_config(LayoutWindow *lw, ToolbarType type, const ch
 
 void layout_util_status_update_write(LayoutWindow *lw)
 {
-	GtkAction *action;
-	gint n = metadata_queue_length();
-	action = gq_gtk_action_group_get_action(lw->action_group, "SaveMetadata");
-	gq_gtk_action_set_sensitive(action, n > 0);
-	if (n > 0)
-		{
-		g_autofree gchar *buf = g_strdup_printf(_("Number of files with unsaved metadata: %d"), n);
-		g_object_set(G_OBJECT(action), "tooltip", buf, NULL);
-		}
-	else
-		{
-		g_object_set(G_OBJECT(action), "tooltip", _("No unsaved metadata"), NULL);
-		}
+        GtkAction *action;
+        gint n = metadata_queue_length();
+        action = gq_gtk_action_group_get_action(lw->action_group, "SaveMetadata");
+        gq_gtk_action_set_sensitive(action, n > 0);
+
+        const gchar *icon_name = n > 0 ? GQ_ICON_SAVE_AS : GQ_ICON_SAVE;
+
+        struct UpdateIconData
+                {
+                GtkAction *act;
+                const gchar *name;
+                };
+
+        static const auto update_icon_cb = [](GtkWidget *widget, gpointer data)
+                {
+                auto *uid = static_cast<UpdateIconData *>(data);
+                if (!GTK_IS_BUTTON(widget)) return;
+                GtkAction *waction = static_cast<GtkAction *>(g_object_get_data(G_OBJECT(widget), "action"));
+                if (waction != uid->act) return;
+#if HAVE_GTK4
+                GtkWidget *image = gtk_button_get_child(GTK_BUTTON(widget));
+                if (GTK_IS_IMAGE(image))
+                        {
+                        gtk_image_set_from_icon_name(GTK_IMAGE(image), uid->name);
+                        }
+#else
+                GtkWidget *image = gtk_button_get_image(GTK_BUTTON(widget));
+                if (GTK_IS_IMAGE(image))
+                        {
+                        gtk_image_set_from_icon_name(GTK_IMAGE(image), uid->name, GTK_ICON_SIZE_SMALL_TOOLBAR);
+                        }
+#endif
+                };
+
+        UpdateIconData uid = {action, icon_name};
+        for (int i = 0; i < TOOLBAR_COUNT; i++)
+                {
+                if (lw->toolbar[i])
+                        {
+                        gtk_container_foreach(GTK_CONTAINER(lw->toolbar[i]), update_icon_cb, &uid);
+                        }
+                }
+
+        g_object_set(G_OBJECT(action), "icon-name", icon_name, NULL);
+
+        if (n > 0)
+                {
+                g_autofree gchar *buf = g_strdup_printf(_("Number of files with unsaved metadata: %d"), n);
+                g_object_set(G_OBJECT(action), "tooltip", buf, NULL);
+                }
+        else
+                {
+                g_object_set(G_OBJECT(action), "tooltip", _("No unsaved metadata"), NULL);
+                }
 }
 
 void layout_util_status_update_write_all()


### PR DESCRIPTION
## Summary
- update `layout_util_status_update_write` to swap SaveMetadata toolbar icon when there are unsaved items
- keep tooltip and sensitivity behaviour as before

## Testing
- `meson setup build` *(fails: Dependency "gtk+-3.0" not found)*
- `meson test -C build` *(fails: No such build data file)*

------
https://chatgpt.com/codex/tasks/task_e_68504cdc38548333a7d96adf68288834